### PR TITLE
[DAT-66] Handle missing path

### DIFF
--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -149,10 +149,6 @@ declare module 'cozy-client' {
     md5sum: string
   }
 
-  type IOCozyFile = {
-    attributes: MissingFileDocumentAttributes & FileDocument
-  } & CozyClientDocument
-
   interface Collection {
     findReferencedBy: (
       params: object

--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -145,10 +145,6 @@ declare module 'cozy-client' {
     }[]
   }
 
-  interface MissingFileDocumentAttributes {
-    md5sum: string
-  }
-
   interface Collection {
     findReferencedBy: (
       params: object

--- a/src/search/SearchEngine.spec.js
+++ b/src/search/SearchEngine.spec.js
@@ -122,19 +122,30 @@ describe('sortSearchResults', () => {
       {
         doctype: FILES_DOCTYPE,
         doc: {
-          name: 'DirName',
+          name: 'DirName1',
           path: 'test1/path',
           type: 'directory',
           _type: FILES_DOCTYPE
         },
         fields: ['path']
+      },
+      {
+        doctype: FILES_DOCTYPE,
+        doc: {
+          name: 'DirName2',
+          path: 'test1/path',
+          type: 'directory',
+          _type: FILES_DOCTYPE
+        },
+        fields: ['name']
       }
     ]
 
     const sortedResults = searchEngine.sortSearchResults(searchResults)
 
-    expect(sortedResults[0].doc.name).toBe('test1') // File match on name
-    expect(sortedResults[1].doc.name).toBe('test11') // File match on name
-    expect(sortedResults[2].doc.name).toBe('DirName') // Directory
+    expect(sortedResults[0].doc.name).toBe('DirName2') // Dir match on name
+    expect(sortedResults[1].doc.name).toBe('test1') // File match on name
+    expect(sortedResults[2].doc.name).toBe('test11') // File match on name
+    expect(sortedResults[3].doc.name).toBe('DirName1') // Directory
   })
 })

--- a/src/search/SearchEngine.ts
+++ b/src/search/SearchEngine.ts
@@ -12,8 +12,6 @@ import {
   DOCTYPE_ORDER,
   LIMIT_DOCTYPE_SEARCH,
   REPLICATION_DEBOUNCE,
-  ROOT_DIR_ID,
-  SHARED_DRIVES_DIR_ID,
   SearchedDoctype
 } from '@/search/consts'
 import { getPouchLink } from '@/search/helpers/client'
@@ -36,6 +34,8 @@ import {
   SearchResult,
   isSearchedDoctype
 } from '@/search/types'
+
+import { shouldKeepFile } from './helpers/normalizeFile'
 
 const log = Minilog('🗂️ [Indexing]')
 
@@ -158,13 +158,7 @@ class SearchEngine {
 
   shouldIndexDoc(doc: CozyDoc): boolean {
     if (isIOCozyFile(doc)) {
-      const notInTrash = !doc.trashed && !/^\/\.cozy_trash/.test(doc.path ?? '')
-      const notRootDir = doc._id !== ROOT_DIR_ID
-      // Shared drives folder to be hidden in search.
-      // The files inside it though must appear. Thus only the file with the folder ID is filtered out.
-      const notSharedDrivesDir = doc._id !== SHARED_DRIVES_DIR_ID
-
-      return notInTrash && notRootDir && notSharedDrivesDir
+      return shouldKeepFile(doc)
     }
     return true
   }

--- a/src/search/helpers/normalizeFile.spec.ts
+++ b/src/search/helpers/normalizeFile.spec.ts
@@ -1,6 +1,6 @@
 import { IOCozyFile } from 'cozy-client/types/types'
 
-import { normalizeFile } from './normalizeFile'
+import { normalizeFileWithFolders } from './normalizeFile'
 
 test('should get path for directories', () => {
   const folders = [] as IOCozyFile[]
@@ -11,7 +11,7 @@ test('should get path for directories', () => {
     path: 'SOME/PATH/'
   } as IOCozyFile
 
-  const result = normalizeFile(folders, file)
+  const result = normalizeFileWithFolders(folders, file)
 
   expect(result).toStrictEqual({
     type: 'directory',
@@ -35,7 +35,7 @@ test(`should get parent folder's path for files`, () => {
     dir_id: 'SOME_DIR_ID'
   } as IOCozyFile
 
-  const result = normalizeFile(folders, file)
+  const result = normalizeFileWithFolders(folders, file)
 
   expect(result).toStrictEqual({
     type: 'file',

--- a/src/search/helpers/normalizeFile.ts
+++ b/src/search/helpers/normalizeFile.ts
@@ -1,7 +1,17 @@
+import CozyClient, { Q } from 'cozy-client'
 import { IOCozyFile } from 'cozy-client/types/types'
 
-import { TYPE_DIRECTORY } from '@/search/consts'
+import {
+  FILES_DOCTYPE,
+  TYPE_DIRECTORY,
+  ROOT_DIR_ID,
+  SHARED_DRIVES_DIR_ID
+} from '@/search/consts'
 import { CozyDoc } from '@/search/types'
+
+interface FileQueryResult {
+  data: IOCozyFile
+}
 
 /**
  * Normalize file for Front usage in <AutoSuggestion> component inside <BarSearchAutosuggest>
@@ -14,7 +24,7 @@ import { CozyDoc } from '@/search/types'
  * @param {IOCozyFile} file - file to normalize
  * @returns file with normalized field to be used in AutoSuggestion
  */
-export const normalizeFile = (
+export const normalizeFileWithFolders = (
   folders: IOCozyFile[],
   file: IOCozyFile
 ): CozyDoc => {
@@ -27,4 +37,35 @@ export const normalizeFile = (
     path = parentDir && parentDir.path ? parentDir.path : ''
   }
   return { ...file, _type: 'io.cozy.files', path }
+}
+
+export const normalizeFileWithStore = async (
+  client: CozyClient,
+  file: IOCozyFile
+): Promise<IOCozyFile> => {
+  const isDir = file.type === TYPE_DIRECTORY
+  let path = ''
+  if (isDir) {
+    path = file.path ?? ''
+  } else {
+    const query = Q(FILES_DOCTYPE).getById(file.dir_id).limitBy(1)
+    // XXX - Take advantage of cozy-client store to avoid querying database
+    const { data: parentDir } = (await client.query(query, {
+      executeFromStore: true,
+      singleDocData: true
+    })) as FileQueryResult
+    const parentPath = parentDir?.path ?? ''
+    path = `${parentPath}/${file.name}`
+  }
+  return { ...file, _type: 'io.cozy.files', path }
+}
+
+export const shouldKeepFile = (file: IOCozyFile): boolean => {
+  const notInTrash = !file.trashed && !/^\/\.cozy_trash/.test(file.path ?? '')
+  const notRootDir = file._id !== ROOT_DIR_ID
+  // Shared drives folder to be hidden in search.
+  // The files inside it though must appear. Thus only the file with the folder ID is filtered out.
+  const notSharedDrivesDir = file._id !== SHARED_DRIVES_DIR_ID
+
+  return notInTrash && notRootDir && notSharedDrivesDir
 }


### PR DESCRIPTION
When replicating files from CouchDB, we do not retrieve path, as it is
not persisted in database.
Therefore, we dynamically compute the path when a search returns files
results.
Note we do it at this moment rather than at replication time, because
this operation requires to query the parent directory, which can be done
directly in-memory through the store once the search index is built,
rather than an additional server query for each replicated file.