### PR TITLE
[DAT-63] feat: Improve search performances

### DIFF
--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -176,10 +176,14 @@ declare module 'cozy-client' {
       queryDefinition: QueryDefinition,
       options?: QueryOptions
     ) => Promise<QueryResult>
-    queryAll: <T>(queryDefinition: QueryDefinition) => Promise<T>
+    queryAll: <T>(
+      queryDefinition: QueryDefinition,
+      options?: QueryOptions
+    ) => Promise<T>
     links: CozyLink[]
     capabilities: ClientCapabilities
     registerPlugin: (Plugin: Function, options: unknown) => void
+    getCollectionFromState: (doctype: string) => unknown
   }
 
   export const createMockClient = (options?: ClientOptions): CozyClient =>

--- a/src/dataproxy/common/DataProxyInterface.ts
+++ b/src/dataproxy/common/DataProxyInterface.ts
@@ -4,7 +4,7 @@ import type { ClientCapabilities } from 'cozy-client/types/types'
 export type { SearchIndexes } from '@/search/types'
 
 export interface DataProxyWorker {
-  search: (query: string) => Promise<unknown>
+  search: (query: string) => unknown
   setClient: (clientData: ClientData) => Promise<void>
 }
 

--- a/src/dataproxy/worker/shared-worker.ts
+++ b/src/dataproxy/worker/shared-worker.ts
@@ -66,7 +66,7 @@ const dataProxy: DataProxyWorker = {
     updateState()
   },
 
-  search: async (query: string) => {
+  search: (query: string) => {
     if (!client) {
       throw new Error(
         'Client is required to execute a search, please initialize CozyClient'
@@ -75,8 +75,11 @@ const dataProxy: DataProxyWorker = {
     if (!searchEngine) {
       throw new Error('SearchEngine is not initialized')
     }
-
-    return searchEngine.search(query)
+    const startSearchTime = performance.now()
+    const results = searchEngine.search(query)
+    const endSearchTime = performance.now()
+    log.debug(`Search took ${endSearchTime - startSearchTime} ms`)
+    return results
   }
 }
 

--- a/src/search/consts.ts
+++ b/src/search/consts.ts
@@ -29,6 +29,7 @@ export const CONTACTS_DOCTYPE = 'io.cozy.contacts'
 export const APPS_DOCTYPE = 'io.cozy.apps'
 
 export const TYPE_DIRECTORY = 'directory'
+export const TYPE_FILE = 'file'
 export const ROOT_DIR_ID = 'io.cozy.files.root-dir'
 export const TRASH_DIR_ID = 'io.cozy.files.trash-dir'
 export const SHARED_DRIVES_DIR_ID = 'io.cozy.files.shared-drives-dir'

--- a/src/search/helpers/normalizeSearchResult.ts
+++ b/src/search/helpers/normalizeSearchResult.ts
@@ -11,14 +11,12 @@ import {
   SearchResult
 } from '@/search/types'
 
-import { normalizeFileWithStore } from './normalizeFile'
-
-export const normalizeSearchResult = async (
+export const normalizeSearchResult = (
   client: CozyClient,
   searchResults: RawSearchResult,
   query: string
-): Promise<SearchResult> => {
-  const doc = await normalizeDoc(client, searchResults.doc)
+): SearchResult => {
+  const doc = searchResults.doc
   const url = buildOpenURL(client, doc)
   const type = getSearchResultSlug(doc)
   const title = getSearchResultTitle(doc)
@@ -30,16 +28,6 @@ export const normalizeSearchResult = async (
   const normalizedRes = { doc, type, title, name, url }
 
   return normalizedRes
-}
-
-const normalizeDoc = async (
-  client: CozyClient,
-  doc: CozyDoc
-): Promise<CozyDoc> => {
-  if (isIOCozyFile(doc)) {
-    return normalizeFileWithStore(client, doc)
-  }
-  return doc
 }
 
 const getSearchResultTitle = (doc: CozyDoc): string | null => {


### PR DESCRIPTION
Since https://github.com/cozy/cozy-web-data-proxy/pull/6, we noticed a severe performance degradation when performing search.

We measured the following:
- Flexsearch search: <ms
- Query cozy-client store to get file paths: ~120ms for 60 files.
- Results normalization: ~3ms

We used to make multiple `getById` queries to get file path, each of them taking few ms. So we tried to use a `getByIds` instead, and got ~70ms per query, which is better, but still slow.
Then, we tried the following:
```
  const allFiles = client.getCollectionFromState(FILES_DOCTYPE) as IOCozyFile[]
  const dirs = allFiles.filter(file => file.type === TYPE_DIRECTORY)
  return dirs.filter(dir => dirIds.includes(dir._id))
```

This takes 2ms.

We should eventually investigate why the store queries are so slow, but for now let's use this trick.

:warning: This is unrelated to this PR, but we also noticed a dramatic performance drop when using Firefox: the postmessage communication takes ~400ms for 100 search results vs 02.ms with Chrome