### PR TITLE
feat: Use storage interface to persist indexes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "comlink": "^4.4.1",
     "cozy-app-publish": "^0.34.0",
     "cozy-client": "^54.0.0",
-    "cozy-dataproxy-lib": "3.4.0",
+    "cozy-dataproxy-lib": "4.1.0",
     "cozy-device-helper": "^3.7.1",
     "cozy-flags": "^4.0.0",
     "cozy-intent": "^2.29.2",

--- a/src/dataproxy/worker/platformWorker.ts
+++ b/src/dataproxy/worker/platformWorker.ts
@@ -100,6 +100,16 @@ const storage = {
   }
 }
 
+export const searchEngineStorage = {
+  storeData: async (key: string, value: unknown): Promise<void> => {
+    return storage.setItem(key, value)
+  },
+  getData: async <T>(key: string): Promise<T | null> => {
+    const item = storage.getItem(key)
+    return item ? (item as T) : null
+  }
+}
+
 const events = {
   addEventListener: (
     eventName: string,

--- a/src/dataproxy/worker/shared-worker.ts
+++ b/src/dataproxy/worker/shared-worker.ts
@@ -1,7 +1,7 @@
 import * as Comlink from 'comlink'
 
 import CozyClient, { StackLink } from 'cozy-client'
-import { SearchEngine } from 'cozy-dataproxy-lib/api'
+import { SearchEngine } from 'cozy-dataproxy-lib'
 import Minilog from 'cozy-minilog'
 import PouchLink from 'cozy-pouch-link'
 
@@ -19,7 +19,10 @@ import {
   SearchOptions
 } from '@/dataproxy/common/DataProxyInterface'
 import { queryIsTrustedDevice } from '@/dataproxy/worker/data'
-import { platformWorker } from '@/dataproxy/worker/platformWorker'
+import {
+  platformWorker,
+  searchEngineStorage
+} from '@/dataproxy/worker/platformWorker'
 import schema from '@/doctypes'
 import { getPouchLink } from '@/helpers/client'
 
@@ -79,7 +82,7 @@ const dataProxy: DataProxyWorker = {
     client.instanceOptions = clientData.instanceOptions
     client.capabilities = clientData.capabilities
 
-    searchEngine = new SearchEngine(client)
+    searchEngine = new SearchEngine(client, searchEngineStorage)
 
     log.debug('Setup done')
     updateState()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,11 +2132,6 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz#707413784dbb3a72aa11c2f2b042a0bef4004170"
   integrity sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==
 
-classnames@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
-  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
-
 cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
@@ -2278,18 +2273,13 @@ cozy-client@^54.0.0:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-dataproxy-lib@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-3.4.0.tgz#67b852b0f6a7586dac1bce8bd29d31d96446a1bd"
-  integrity sha512-OVf16ysV804JEtIRiSS+b7yUoN1HrsW1kgwuKIQMWzI/4K4EGuMRhSiWGFE5Un9HLkJnY4way5b3FOlkXUVvVw==
+cozy-dataproxy-lib@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-dataproxy-lib/-/cozy-dataproxy-lib-4.1.0.tgz#20d0a38e059fb5924d85f3b5a550d7d28ec9a477"
+  integrity sha512-k5lVjnpPmATEUZaYeK0B8J0+ntiNRmpmTXyDi8p6H7y41LO/yZ0XhbIqxbO4PjPnT8aKFWx3zQ7LGqIXS2Y7LA==
   dependencies:
-    classnames "2.5.1"
     comlink "4.4.1"
     flexsearch "0.7.43"
-    lodash "4.17.21"
-    mime-types "2.1.35"
-    react-type-animation "3.2.0"
-    rooks "7.14.1"
 
 cozy-device-helper@^3.7.1:
   version "3.7.1"
@@ -4636,17 +4626,12 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.17.21, lodash@^4.14.2, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.21:
+lodash@^4.14.2, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4734,7 +4719,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@2.1.35, mime-types@^2.1.12, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -5439,13 +5424,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-raf@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -5500,11 +5478,6 @@ react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
-
-react-type-animation@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-type-animation/-/react-type-animation-3.2.0.tgz#6863d5d60e3beb237f2bd690cceb585402c47e6a"
-  integrity sha512-WXTe0i3rRNKjmggPvT5ntye1QBt0ATGbijeW6V3cQe2W0jaMABXXlPPEdtofnS9tM7wSRHchEvI9SUw+0kUohw==
 
 react@^18.3.1:
   version "18.3.1"
@@ -5701,16 +5674,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-rooks@7.14.1:
-  version "7.14.1"
-  resolved "https://registry.yarnpkg.com/rooks/-/rooks-7.14.1.tgz#f3660752c299da02eb6cc733c55f8270c3376a87"
-  integrity sha512-oPuLNGm3OaFm3WfZHzmDvJvRit8QrXGm9/Kn49Bz8lJUjkThSBtERWzuQ9wb5DveqrpUZvmNyBXjBE0KWVt13w==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    lodash.debounce "^4.0.8"
-    raf "^3.4.1"
-    use-sync-external-store "^1.2.0"
 
 rsbuild-plugin-ejs@^1.0.1:
   version "1.0.1"
@@ -6390,11 +6353,6 @@ url@^0.11.3:
   dependencies:
     punycode "^1.4.1"
     qs "^6.12.3"
-
-use-sync-external-store@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
-  integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This had been made mainly for mobile, but it's still useful for web  as it avoids recomputing indexes each time the dataproxy starts