### PR TITLE
feat: Inform when dataproxy is ready

### DIFF
--- a/src/dataproxy/parent/ParentWindowProvider.tsx
+++ b/src/dataproxy/parent/ParentWindowProvider.tsx
@@ -15,6 +15,11 @@ interface ParentWindowProviderProps {
   children: ReactNode
 }
 
+const sendReadyMessage = (): void => {
+  // This is useful to inform the parent apps that the DataProxy's iframe is ready to be requested
+  window.parent.postMessage({ type: 'DATAPROXYMESSAGE', payload: 'READY' }, '*')
+}
+
 export const ParentWindowProvider = React.memo(
   ({ children }: ParentWindowProviderProps) => {
     const workerContext = useSharedWorker()
@@ -31,6 +36,7 @@ export const ParentWindowProvider = React.memo(
     }
 
     Comlink.expose(iframeProxy, Comlink.windowEndpoint(parent))
+    sendReadyMessage()
 
     if (!workerContext) return undefined
 

--- a/src/dataproxy/worker/SharedWorkerProvider.tsx
+++ b/src/dataproxy/worker/SharedWorkerProvider.tsx
@@ -62,7 +62,7 @@ export const SharedWorkerProvider = React.memo(
         log.debug('Provide CozyClient data to SharedWorker')
         const { uri, token } = client.getStackClient()
 
-        obj.setup({
+        await obj.setup({
           uri,
           token: token.token,
           instanceOptions: client.instanceOptions,


### PR DESCRIPTION
Parent apps need a way to knwo when the DataProxy is ready to be requested.
Otherwise, errors could occur because the init is not done.