### PR TITLE
feat: Reconnect realtime inside shared worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cozy-logger": "^1.10.4",
     "cozy-minilog": "^3.3.1",
     "cozy-pouch-link": "58.2.0",
-    "cozy-realtime": "^5.6.4",
+    "cozy-realtime": "^5.7.0",
     "cozy-tsconfig": "^1.2.0",
     "flexsearch": "^0.7.43",
     "lodash": "^4.17.21",

--- a/src/@types/cozy-client.d.ts
+++ b/src/@types/cozy-client.d.ts
@@ -9,6 +9,7 @@ import {
   QueryResult,
   ClientCapabilities
 } from 'cozy-client/types/types'
+import { RealtimePlugin } from 'cozy-realtime'
 
 declare module 'cozy-client' {
   interface ClientOptions {
@@ -69,6 +70,10 @@ declare module 'cozy-client' {
 
   interface FlagshipVerificationNeededResult {
     session_code: string
+  }
+
+  interface Plugins {
+    realtime: RealtimePlugin
   }
 
   type LoginFlagshipResult =
@@ -163,7 +168,7 @@ declare module 'cozy-client' {
   }
 
   export default class CozyClient {
-    plugins: unknown
+    plugins: Plugins
     constructor(rawOptions?: ClientOptions)
     getStackClient(): StackClient
     getInstanceOptions(): InstanceOptions

--- a/src/dataproxy/common/DataProxyInterface.ts
+++ b/src/dataproxy/common/DataProxyInterface.ts
@@ -19,6 +19,7 @@ export interface DataProxyWorker {
     definition: QueryDefinition | Mutation,
     options?: QueryOptions | MutationOptions
   ) => Promise<unknown>
+  reconnectRealtime: () => void
 }
 
 export interface DataProxyWorkerPartialState {

--- a/src/dataproxy/parent/ParentWindowProvider.tsx
+++ b/src/dataproxy/parent/ParentWindowProvider.tsx
@@ -51,6 +51,16 @@ export const ParentWindowProvider = React.memo(
     Comlink.expose(iframeProxy, Comlink.windowEndpoint(parent))
     sendReadyMessage()
 
+    window.addEventListener('online', () => {
+      // This reconnection is normally done by cozy-realtime itself after an online event.
+      // See https://github.com/cozy/cozy-libs/blob/e65ef0b285982ef58269f766870bcb26fee91ef4/packages/cozy-realtime/src/CozyRealtime.js#L578
+      // However, this does not work for the shared worker as the online event is not available there.
+      // Thus, we catch this event in the ParentWindowProvider, to manually reconnect the realtime inside the shared worker.
+      // Note it might be good to eventually handle it on the cozy-realtime side, through some websocket ping/pong with the server,
+      // to periodically check whether the connection is still alive
+      return workerContext.worker.reconnectRealtime()
+    })
+
     if (!workerContext) return undefined
 
     return (

--- a/src/dataproxy/worker/shared-worker.ts
+++ b/src/dataproxy/worker/shared-worker.ts
@@ -174,6 +174,16 @@ const dataProxy: DataProxyWorker = {
     if (pouchLink) {
       pouchLink.startReplication()
     }
+  },
+
+  reconnectRealtime: () => {
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/unbound-method */
+    const realtime = client?.plugins?.realtime
+    if (realtime) {
+      realtime.reconnect()
+      dataProxy.forceSyncPouch()
+      searchEngine.init() // Init again to refresh indexes
+    }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2380,10 +2380,10 @@ cozy-pouch-link@58.2.0:
     pouchdb-browser "^7.2.2"
     pouchdb-find "^7.2.2"
 
-cozy-realtime@^5.6.4:
-  version "5.6.4"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-5.6.4.tgz#8546ffbd4882243bd785ef29f33bb0c74e444e16"
-  integrity sha512-kI43e4lDi8MXAkGF5id5joZco6rQVH/acTuW0tCp7FklM2ZT02mujwIBnDE59QWAn5nmaSakL7VA6dqdgfP6hQ==
+cozy-realtime@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-5.7.0.tgz#df3bf3124d8291fd2bb0ec2dd69addd8ec0b7a63"
+  integrity sha512-v1iev1qydt8jgWpjdmI2XsDMghzQvQESi4po6jnW3IISJzLKffJwKxySKtz2OSngRZ7l2wEznLTgALv2sL8y4A==
   dependencies:
     "@cozy/minilog" "^1.0.0"
 


### PR DESCRIPTION
This reconnection is normally done by cozy-realtime itself after an online event.  See
https://github.com/cozy/cozy-libs/blob/e65ef0b285982ef58269f766870bcb26fee91ef4/packages/cozy-realtime/src/CozyRealtime.js#L578 However, this does not work for the shared worker as the online event is not available there.  Thus, we catch this event in the ParentWindowProvider, to manually reconnect the realtime inside the shared worker.  Note it might be good to eventually handle it on the cozy-realtime side, through some websocket ping/pong with the server, to periodically check whether the connection is still alive