### PR TITLE
fix: SharedWorkerGlobalScope is not defined

### DIFF
--- a/src/dataproxy/worker/worker.ts
+++ b/src/dataproxy/worker/worker.ts
@@ -215,7 +215,10 @@ const updateState = (): void => {
   broadcastChannel.postMessage(state)
 }
 
-if (self instanceof SharedWorkerGlobalScope) {
+if (
+  typeof SharedWorkerGlobalScope !== 'undefined' &&
+  self instanceof SharedWorkerGlobalScope
+) {
   onconnect = (e: MessageEvent): void => {
     const port = e.ports[0]
 


### PR DESCRIPTION
In https://github.com/cozy/cozy-web-data-proxy/commit/4071273f43aab39f5165280d95d95df68e4807eb

we adapt Comlink to be run on sharedworker or on dedicatedworker

But we got error on dedicatedworker saying:
SharedWorkerGlobalScope is not defined.

So let's test it before trying to read it.