### PR TITLE
fix: repair shared drive databases left broken by older dataproxy versions

### DIFF
--- a/src/dataproxy/worker/sharedDrivePouchReset.spec.ts
+++ b/src/dataproxy/worker/sharedDrivePouchReset.spec.ts
@@ -1,7 +1,10 @@
 import 'fake-indexeddb/auto'
 
 import { platformWorker } from '@/dataproxy/worker/platformWorker'
-import { resetSharedDrivePouchesOnce } from '@/dataproxy/worker/sharedDrivePouchReset'
+import {
+  RESET_VERSION,
+  resetSharedDrivePouchesOnce
+} from '@/dataproxy/worker/sharedDrivePouchReset'
 
 const storageData = new Map<string, unknown>()
 
@@ -82,7 +85,10 @@ describe('resetSharedDrivePouchesOnce', () => {
     expect(storageData.has(`@dataproxy:${DOCTYPE}:searchIndexLastSeq`)).toBe(
       false
     )
-    expect(storageData.get(MARKER_KEY)).toEqual({ [DOCTYPE]: true })
+    expect(storageData.get(MARKER_KEY)).toEqual({
+      version: RESET_VERSION,
+      doctypes: { [DOCTYPE]: true }
+    })
 
     // A database recreated by the resync must not be deleted again
     await createDatabase(DB_NAME)
@@ -91,7 +97,10 @@ describe('resetSharedDrivePouchesOnce', () => {
   })
 
   it('resets drives that appear after a previous reset', async () => {
-    storageData.set(MARKER_KEY, { [DOCTYPE]: true })
+    storageData.set(MARKER_KEY, {
+      version: RESET_VERSION,
+      doctypes: { [DOCTYPE]: true }
+    })
     const otherDoctype = 'io.cozy.files.shareddrives-drive2'
     const otherDbName = `_pouch_alice.localhost:8080__doctype__${otherDoctype}`
     await createDatabase(otherDbName)
@@ -100,8 +109,23 @@ describe('resetSharedDrivePouchesOnce', () => {
 
     expect(await databaseExists(otherDbName)).toBe(false)
     expect(storageData.get(MARKER_KEY)).toEqual({
-      [DOCTYPE]: true,
-      [otherDoctype]: true
+      version: RESET_VERSION,
+      doctypes: { [DOCTYPE]: true, [otherDoctype]: true }
+    })
+  })
+
+  it('repairs a drive again when its marker predates the current reset version', async () => {
+    // A marker from before version gating (or an older version) must not stop
+    // the repair from running again under the current version.
+    storageData.set(MARKER_KEY, { [DOCTYPE]: true })
+    await createDatabase(DB_NAME)
+
+    await resetSharedDrivePouchesOnce(URI, [DRIVE_ID])
+
+    expect(await databaseExists(DB_NAME)).toBe(false)
+    expect(storageData.get(MARKER_KEY)).toEqual({
+      version: RESET_VERSION,
+      doctypes: { [DOCTYPE]: true }
     })
   })
 

--- a/src/dataproxy/worker/sharedDrivePouchReset.ts
+++ b/src/dataproxy/worker/sharedDrivePouchReset.ts
@@ -7,6 +7,18 @@ const log = Minilog('👷‍♂️ [SharedDrivePouchReset]')
 
 const RESET_MARKER_KEY = 'shared-drive-pouches-rewrite-reset'
 
+// Bump to force a one-time repair sweep across every shared-drive database on
+// the next worker startup, even ones a previous version already marked as reset.
+// This is needed when an earlier build recorded a reset that did not actually
+// fix the database, e.g. the reset ran before the pouchdb-adapter-indexeddb
+// rewrite patch was effective, so the resync re-stored documents unescaped.
+export const RESET_VERSION = 2
+
+interface ResetMarker {
+  version: number
+  doctypes: Record<string, boolean>
+}
+
 const DELETE_DATABASE_TIMEOUT = 10 * 1000
 
 // Storage keys owned by cozy-pouch-link (see cozy-pouch-link/src/localStorage.js)
@@ -90,11 +102,20 @@ const removeSearchIndexData = async (doctype: string): Promise<void> => {
   }
 }
 
-const getResetDoctypes = async (): Promise<Record<string, boolean>> => {
-  const marker = await platformWorker.storage.getItem(RESET_MARKER_KEY)
-  return marker && typeof marker === 'object'
-    ? (marker as Record<string, boolean>)
-    : {}
+const getResetMarker = async (): Promise<ResetMarker> => {
+  const stored = await platformWorker.storage.getItem(RESET_MARKER_KEY)
+  const marker = stored as ResetMarker | null
+  if (
+    marker &&
+    typeof marker === 'object' &&
+    marker.version === RESET_VERSION &&
+    typeof marker.doctypes === 'object'
+  ) {
+    return marker
+  }
+  // No marker, the pre-version format, or an older version: start a fresh sweep
+  // so every database is repaired once under the current reset version.
+  return { version: RESET_VERSION, doctypes: {} }
 }
 
 /**
@@ -110,18 +131,20 @@ const getResetDoctypes = async (): Promise<Record<string, boolean>> => {
  * stays empty.
  *
  * The marker records each reset doctype individually, so a drive that fails
- * mid-reset or only appears in a later session is still reset.
+ * mid-reset or only appears in a later session is still reset. It is scoped to
+ * RESET_VERSION, so bumping that constant repairs every drive again once, even
+ * ones an earlier (ineffective) version already marked.
  */
-export const resetSharedDrivePouchesOnce = async (
+const resetSharedDrivePouches = async (
   uri: string,
   sharedDriveIds: string[]
 ): Promise<void> => {
-  const resetDoctypes = await getResetDoctypes()
+  const marker = await getResetMarker()
   const prefix = uri.replace(/^https?:\/\//, '')
 
   for (const driveId of sharedDriveIds) {
     const doctype = `${SHARED_DRIVE_FILE_DOCTYPE}-${driveId}`
-    if (resetDoctypes[doctype]) continue
+    if (marker.doctypes[doctype]) continue
 
     log.info(`Resetting local database for ${doctype}`)
     await deleteDatabase(`_pouch_${prefix}__doctype__${doctype}`)
@@ -130,7 +153,24 @@ export const resetSharedDrivePouchesOnce = async (
     }
     await removeSearchIndexData(doctype)
 
-    resetDoctypes[doctype] = true
-    await platformWorker.storage.setItem(RESET_MARKER_KEY, resetDoctypes)
+    marker.doctypes[doctype] = true
+    await platformWorker.storage.setItem(RESET_MARKER_KEY, marker)
   }
+}
+
+// setup() and addSharedDrive() can both reach the reset, so serialize the calls
+// to keep the read-modify-write on the shared marker atomic: overlapping calls
+// would otherwise clobber each other's entries and re-reset drives needlessly.
+let resetQueue: Promise<void> = Promise.resolve()
+
+export const resetSharedDrivePouchesOnce = (
+  uri: string,
+  sharedDriveIds: string[]
+): Promise<void> => {
+  const run = resetQueue.then(() =>
+    resetSharedDrivePouches(uri, sharedDriveIds)
+  )
+  // Keep the queue alive even if a run rejects, so later resets still proceed
+  resetQueue = run.catch(() => undefined)
+  return run
 }

--- a/src/dataproxy/worker/worker.ts
+++ b/src/dataproxy/worker/worker.ts
@@ -248,6 +248,16 @@ const dataProxy: DataProxyWorker = {
     }
     const pouchLink = getPouchLink(client)
     if (pouchLink) {
+      // A drive opened after setup never went through the setup-time reset, so
+      // repair its pre-patch poisoned database here before replicating into it.
+      try {
+        await resetSharedDrivePouchesOnce(client.getStackClient().uri, [
+          driveId
+        ])
+      } catch (e) {
+        log.error('Failed to reset shared drive database', e)
+      }
+
       const doctype = `${SHARED_DRIVE_FILE_DOCTYPE}-${driveId}`
       const replicationOptions = { strategy: 'fromRemote', driveId }
       const options = { shouldStartReplication: true }


### PR DESCRIPTION
## Problem

Shared drive files vanish from Recents and Search after a refresh when their local database was first synced by an older dataproxy (before the pouchdb-adapter-indexeddb rewrite patch). The docs were stored unescaped, so the Mango indexes never match them and queries return nothing.

The existing repair only ran at startup for drives already known then, which is none while the shared-drive flag is still loading. Drives opened later were never repaired.

## Solution

- Repair a drive from `addSharedDrive()` too, not just at startup, so drives opened later are fixed before they sync.
- Version the reset marker so upgrading repairs every drive once more, even ones a previous build wrongly marked as done.
- Serialize reset calls so overlapping ones cannot clobber the shared marker.