### PR TITLE
fix: trust OIDC devices so shared drives reach recents and search

### DIFF
--- a/src/dataproxy/worker/data.spec.ts
+++ b/src/dataproxy/worker/data.spec.ts
@@ -1,0 +1,65 @@
+import type CozyClient from 'cozy-client'
+
+import type { ClientData } from '@/dataproxy/common/DataProxyInterface'
+import { queryIsTrustedDevice } from '@/dataproxy/worker/data'
+
+const makeClient = (attributes: Record<string, unknown>): CozyClient =>
+  ({
+    getStackClient: () => ({
+      fetchJSON: (): Promise<unknown> =>
+        Promise.resolve({ data: { attributes } })
+    })
+  }) as unknown as CozyClient
+
+const makeClientData = (over: Partial<ClientData> = {}): ClientData =>
+  ({
+    uri: 'https://alice.localhost',
+    token: 'token',
+    instanceOptions: { flags: {} },
+    capabilities: {},
+    useRemoteData: false,
+    ...over
+  }) as unknown as ClientData
+
+describe('queryIsTrustedDevice', () => {
+  it('trusts a long-running session', async () => {
+    const trusted = await queryIsTrustedDevice(
+      makeClient({ long_run: true }),
+      makeClientData()
+    )
+    expect(trusted).toBe(true)
+  })
+
+  it('does not trust a short session on a password instance', async () => {
+    const trusted = await queryIsTrustedDevice(
+      makeClient({ long_run: false }),
+      makeClientData()
+    )
+    expect(trusted).toBe(false)
+  })
+
+  it('trusts a short session on an OIDC instance', async () => {
+    const trusted = await queryIsTrustedDevice(
+      makeClient({ long_run: false }),
+      makeClientData({ capabilities: { can_auth_with_oidc: true } })
+    )
+    expect(trusted).toBe(true)
+  })
+
+  it('trusts when the stack does not report long_run', async () => {
+    const trusted = await queryIsTrustedDevice(makeClient({}), makeClientData())
+    expect(trusted).toBe(true)
+  })
+
+  it('trusts when the force-trusted-device flag is set', async () => {
+    const trusted = await queryIsTrustedDevice(
+      makeClient({ long_run: false }),
+      makeClientData({
+        instanceOptions: {
+          flags: { 'dataproxy.force-trusted-device.enabled': true }
+        }
+      } as unknown as Partial<ClientData>)
+    )
+    expect(trusted).toBe(true)
+  })
+})

--- a/src/dataproxy/worker/data.ts
+++ b/src/dataproxy/worker/data.ts
@@ -46,14 +46,17 @@ export const queryIsTrustedDevice = async (
     return true
   }
 
-  const isLongRun = resp?.data?.attributes?.long_run
-  const isUnDefined = isLongRun === undefined
-
-  if (isUnDefined) {
-    return true // special case for twake instances with linagora SSO
-  } else {
-    return !!isLongRun
+  // On OIDC instances long_run is not a reliable trust signal, so trust the device
+  if (clientData.capabilities?.can_auth_with_oidc) {
+    return true
   }
+
+  const isLongRun = resp?.data?.attributes?.long_run
+  if (isLongRun === undefined) {
+    return true
+  }
+
+  return isLongRun
 }
 
 const deleteDatabases = async (): Promise<void> => {


### PR DESCRIPTION
## Problem

On a recipient instance, shared drive files never show up in Recents or Search. The dataproxy only replicates data locally when the device is "trusted", and it infers trust from the session `long_run` flag. OIDC logins always create non long-run sessions, so the device is always judged untrusted, nothing is replicated locally, and Recents/Search fall back to local-only queries that exclude shared drives.

## Solution

Treat the device as trusted when the instance supports OIDC login, where `long_run` is not a meaningful trust signal. Behaviour is unchanged for long-running sessions, the force-trusted flag, and stacks that do not report `long_run`.

## Worth knowing

This trust check gates all local replication in the dataproxy (files, contacts, settings, and the rest), not only shared drives. So on OIDC instances this enables local caching of all those doctypes for every session, including short ones. It restores the behaviour that existed when the stack left `long_run` unset, but it is a wider change than shared drives alone.

Whether an OIDC session should cache private data locally by default is a product/security decision. If the answer is "not always", trust should come from a dedicated signal (an explicit opt-in, or an instance setting the dataproxy reads) rather than being inferred from `long_run` here.