### PR TITLE
fix: sort recents results by updated_at descending across all doctypes

### DIFF
--- a/src/dataproxy/worker/data.ts
+++ b/src/dataproxy/worker/data.ts
@@ -140,5 +140,16 @@ export const queryRecents = async (client: CozyClient): Promise<unknown[]> => {
     }>
   ).flatMap(recentResult => recentResult.data || [])
 
+  // Sort results from all doctypes by updated_at descending
+  recents.sort((a, b) => {
+    const dateA = new Date(
+      (a as Record<string, string>).updated_at ?? 0
+    ).getTime()
+    const dateB = new Date(
+      (b as Record<string, string>).updated_at ?? 0
+    ).getTime()
+    return dateB - dateA
+  })
+
   return recents
 }


### PR DESCRIPTION
Problem: 

In recents, we got the local files first and then the files from dataproxy