### PR TITLE
fix: stop a revoked shared drive from breaking recents

### DIFF
--- a/src/dataproxy/worker/data.spec.ts
+++ b/src/dataproxy/worker/data.spec.ts
@@ -1,7 +1,35 @@
 import type CozyClient from 'cozy-client'
 
 import type { ClientData } from '@/dataproxy/common/DataProxyInterface'
-import { queryIsTrustedDevice } from '@/dataproxy/worker/data'
+import {
+  findSharedDriveDrift,
+  queryIsTrustedDevice,
+  queryRecents,
+  queryRecentsHandlingStaleDrives
+} from '@/dataproxy/worker/data'
+import { getPouchLink } from '@/helpers/client'
+
+jest.mock('@/helpers/client')
+const mockedGetPouchLink = getPouchLink as jest.MockedFunction<
+  typeof getPouchLink
+>
+
+const make403 = (): Error =>
+  Object.assign(new Error('Forbidden'), { status: 403 })
+
+const setupPouchLink = (requestQuery: jest.Mock): CozyClient => {
+  mockedGetPouchLink.mockReturnValue({
+    doctypes: [
+      'io.cozy.files',
+      'io.cozy.files.shareddrives-active',
+      'io.cozy.files.shareddrives-revoked'
+    ],
+    pouches: {
+      waitForCurrentReplications: jest.fn().mockResolvedValue(undefined)
+    }
+  } as unknown as ReturnType<typeof getPouchLink>)
+  return { requestQuery } as unknown as CozyClient
+}
 
 const makeClient = (attributes: Record<string, unknown>): CozyClient =>
   ({
@@ -61,5 +89,210 @@ describe('queryIsTrustedDevice', () => {
       } as unknown as Partial<ClientData>)
     )
     expect(trusted).toBe(true)
+  })
+})
+
+describe('queryRecents', () => {
+  it('does not query shared drives flagged as stale', async () => {
+    const requestQuery = jest.fn((definition: { doctype: string }) =>
+      Promise.resolve({
+        data: [{ _id: definition.doctype, updated_at: '2026-01-01T00:00:00Z' }]
+      })
+    )
+
+    const recents = await queryRecents(setupPouchLink(requestQuery), [
+      'revoked'
+    ])
+
+    const queried = requestQuery.mock.calls.map(
+      call => (call[0] as { doctype: string }).doctype
+    )
+    expect(queried).toEqual([
+      'io.cozy.files',
+      'io.cozy.files.shareddrives-active'
+    ])
+    expect(recents).toHaveLength(2)
+  })
+
+  it('surfaces a failure for a drive that is not flagged stale', async () => {
+    const requestQuery = jest.fn((definition: { doctype: string }) =>
+      definition.doctype === 'io.cozy.files.shareddrives-revoked'
+        ? Promise.reject(make403())
+        : Promise.resolve({ data: [] })
+    )
+
+    await expect(
+      queryRecents(setupPouchLink(requestQuery))
+    ).rejects.toMatchObject({ status: 403 })
+  })
+})
+
+describe('findSharedDriveDrift', () => {
+  const setup = (doctypes: string[], accessibleIds: string[]): CozyClient => {
+    mockedGetPouchLink.mockReturnValue({
+      doctypes
+    } as unknown as ReturnType<typeof getPouchLink>)
+    return {
+      collection: () => ({
+        fetchSharedDrives: (): Promise<unknown> =>
+          Promise.resolve({ data: accessibleIds.map(id => ({ _id: id })) })
+      })
+    } as unknown as CozyClient
+  }
+
+  it('reports drives indexed locally but missing from the stack as stale', async () => {
+    const client = setup(
+      [
+        'io.cozy.files',
+        'io.cozy.files.shareddrives-active',
+        'io.cozy.files.shareddrives-revoked'
+      ],
+      ['active']
+    )
+    expect(await findSharedDriveDrift(client)).toEqual({
+      staleDriveIds: ['revoked'],
+      missingDriveIds: []
+    })
+  })
+
+  it('reports drives present on the stack but not indexed locally as missing', async () => {
+    const client = setup(
+      ['io.cozy.files', 'io.cozy.files.shareddrives-active'],
+      ['active', 'fresh']
+    )
+    expect(await findSharedDriveDrift(client)).toEqual({
+      staleDriveIds: [],
+      missingDriveIds: ['fresh']
+    })
+  })
+
+  it('reports nothing when local drives and the stack agree', async () => {
+    const client = setup(
+      ['io.cozy.files', 'io.cozy.files.shareddrives-active'],
+      ['active']
+    )
+    expect(await findSharedDriveDrift(client)).toEqual({
+      staleDriveIds: [],
+      missingDriveIds: []
+    })
+  })
+
+  it('returns empty drift when there is no pouch link', async () => {
+    mockedGetPouchLink.mockReturnValue(
+      undefined as unknown as ReturnType<typeof getPouchLink>
+    )
+    const fetchSharedDrives = jest.fn()
+    const client = {
+      collection: () => ({ fetchSharedDrives })
+    } as unknown as CozyClient
+
+    expect(await findSharedDriveDrift(client)).toEqual({
+      staleDriveIds: [],
+      missingDriveIds: []
+    })
+    expect(fetchSharedDrives).not.toHaveBeenCalled()
+  })
+})
+
+describe('queryRecentsHandlingStaleDrives', () => {
+  const REVOKED = 'io.cozy.files.shareddrives-revoked'
+
+  const makeClient = (
+    requestQuery: jest.Mock,
+    fetchSharedDrives: jest.Mock
+  ): CozyClient => {
+    mockedGetPouchLink.mockReturnValue({
+      doctypes: ['io.cozy.files', 'io.cozy.files.shareddrives-active', REVOKED],
+      pouches: {
+        waitForCurrentReplications: jest.fn().mockResolvedValue(undefined)
+      }
+    } as unknown as ReturnType<typeof getPouchLink>)
+    return {
+      requestQuery,
+      collection: () => ({ fetchSharedDrives })
+    } as unknown as CozyClient
+  }
+
+  const resolveExcept = (failing: string, error: Error): jest.Mock =>
+    jest.fn((definition: { doctype: string }) =>
+      definition.doctype === failing
+        ? Promise.reject(error)
+        : Promise.resolve({
+            data: [{ _id: definition.doctype, updated_at: '2026-01-01' }]
+          })
+    )
+
+  it('recovers from a 403 by dropping the stale drive and retrying', async () => {
+    const requestQuery = resolveExcept(REVOKED, make403())
+    const fetchSharedDrives = jest
+      .fn()
+      .mockResolvedValue({ data: [{ _id: 'active' }] })
+    const onStale = jest.fn().mockResolvedValue(undefined)
+    const onMissing = jest.fn().mockResolvedValue(undefined)
+
+    const recents = await queryRecentsHandlingStaleDrives(
+      makeClient(requestQuery, fetchSharedDrives),
+      onStale,
+      onMissing
+    )
+
+    expect(onStale).toHaveBeenCalledWith(['revoked'])
+    expect(onMissing).not.toHaveBeenCalled()
+    expect(fetchSharedDrives).toHaveBeenCalledTimes(1)
+    expect(recents).toHaveLength(2)
+  })
+
+  it('syncs a drive present on the stack but missing locally', async () => {
+    const requestQuery = resolveExcept(REVOKED, make403())
+    const fetchSharedDrives = jest
+      .fn()
+      .mockResolvedValue({ data: [{ _id: 'active' }, { _id: 'fresh' }] })
+    const onStale = jest.fn().mockResolvedValue(undefined)
+    const onMissing = jest.fn().mockResolvedValue(undefined)
+
+    await queryRecentsHandlingStaleDrives(
+      makeClient(requestQuery, fetchSharedDrives),
+      onStale,
+      onMissing
+    )
+
+    expect(onMissing).toHaveBeenCalledWith(['fresh'])
+    expect(onStale).toHaveBeenCalledWith(['revoked'])
+  })
+
+  it('does not reconcile when the recents query succeeds', async () => {
+    const requestQuery = jest.fn(() => Promise.resolve({ data: [] }))
+    const fetchSharedDrives = jest.fn()
+    const onStale = jest.fn()
+    const onMissing = jest.fn()
+
+    await queryRecentsHandlingStaleDrives(
+      makeClient(requestQuery, fetchSharedDrives),
+      onStale,
+      onMissing
+    )
+
+    expect(fetchSharedDrives).not.toHaveBeenCalled()
+    expect(onStale).not.toHaveBeenCalled()
+    expect(onMissing).not.toHaveBeenCalled()
+  })
+
+  it('rethrows the original error when there is no drift', async () => {
+    const requestQuery = resolveExcept(REVOKED, new Error('Boom'))
+    const fetchSharedDrives = jest
+      .fn()
+      .mockResolvedValue({ data: [{ _id: 'active' }, { _id: 'revoked' }] })
+    const onStale = jest.fn()
+    const onMissing = jest.fn()
+
+    await expect(
+      queryRecentsHandlingStaleDrives(
+        makeClient(requestQuery, fetchSharedDrives),
+        onStale,
+        onMissing
+      )
+    ).rejects.toThrow('Boom')
+    expect(onStale).not.toHaveBeenCalled()
+    expect(onMissing).not.toHaveBeenCalled()
   })
 })

--- a/src/dataproxy/worker/data.ts
+++ b/src/dataproxy/worker/data.ts
@@ -2,7 +2,11 @@ import CozyClient, { Q, QueryDefinition } from 'cozy-client'
 import { QueryOptions } from 'cozy-client/types/types'
 import Minilog from 'cozy-minilog'
 
-import { LOCALSTORAGE_KEY_DELETING_DATA, FILES_DOCTYPE } from '@/consts'
+import {
+  LOCALSTORAGE_KEY_DELETING_DATA,
+  FILES_DOCTYPE,
+  SHARED_DRIVE_FILE_DOCTYPE
+} from '@/consts'
 import { getPouchLink } from '@/helpers/client'
 
 import { ClientData } from '../common/DataProxyInterface'
@@ -115,7 +119,10 @@ function buildRecentsQuery(doctype: string): {
   }
 }
 
-export const queryRecents = async (client: CozyClient): Promise<unknown[]> => {
+export const queryRecents = async (
+  client: CozyClient,
+  staleSharedDriveIds: string[] = []
+): Promise<unknown[]> => {
   if (!client) {
     throw new Error('Client is not initialized')
   }
@@ -123,8 +130,14 @@ export const queryRecents = async (client: CozyClient): Promise<unknown[]> => {
   if (!pouchLink) {
     throw new Error('PouchLink is not initialized')
   }
-  const doctypes = pouchLink.doctypes.filter(doctype =>
-    doctype.startsWith(FILES_DOCTYPE)
+
+  // Skip shared drives the user was removed from: querying them makes the stack
+  // answer 403 and rejects the whole batch
+  const staleDoctypes = new Set(
+    staleSharedDriveIds.map(id => `${SHARED_DRIVE_FILE_DOCTYPE}-${id}`)
+  )
+  const doctypes = pouchLink.doctypes.filter(
+    doctype => doctype.startsWith(FILES_DOCTYPE) && !staleDoctypes.has(doctype)
   )
 
   // to be sure to have all the shared drives at first page display
@@ -152,4 +165,80 @@ export const queryRecents = async (client: CozyClient): Promise<unknown[]> => {
   })
 
   return recents
+}
+
+interface SharedDrive {
+  _id: string
+  owner?: boolean
+}
+
+export interface SharedDriveDrift {
+  // indexed locally but the user is no longer a recipient (stack answers 403)
+  staleDriveIds: string[]
+  // a recipient on the stack but never indexed locally (needs a full sync)
+  missingDriveIds: string[]
+}
+
+/**
+ * Compares the shared drives indexed locally against the ones the stack reports
+ * the user is a recipient of, and returns the drift both ways: drives gone stale
+ * locally (the stack now answers 403 for them) and drives present on the stack
+ * but missing locally (they need a full sync to show up in recents and search).
+ */
+export const findSharedDriveDrift = async (
+  client: CozyClient
+): Promise<SharedDriveDrift> => {
+  const empty: SharedDriveDrift = { staleDriveIds: [], missingDriveIds: [] }
+  const pouchLink = getPouchLink(client)
+  if (!pouchLink) {
+    return empty
+  }
+
+  const prefix = `${SHARED_DRIVE_FILE_DOCTYPE}-`
+  const localDriveIds = pouchLink.doctypes
+    .filter(doctype => doctype.startsWith(prefix))
+    .map(doctype => doctype.slice(prefix.length))
+
+  const { data: sharedDrives } = await client
+    .collection('io.cozy.sharings')
+    .fetchSharedDrives()
+  const accessibleDriveIds = (sharedDrives as SharedDrive[])
+    .filter(drive => !drive.owner)
+    .map(drive => drive._id)
+
+  const localSet = new Set(localDriveIds)
+  const accessibleSet = new Set(accessibleDriveIds)
+
+  return {
+    staleDriveIds: localDriveIds.filter(id => !accessibleSet.has(id)),
+    missingDriveIds: accessibleDriveIds.filter(id => !localSet.has(id))
+  }
+}
+
+/**
+ * Runs the recents query. If it fails, the reconcile compares the local shared
+ * drives against the stack: it lets the caller drop drives gone stale (the stack
+ * answers 403 for them) and sync back drives present on the stack but missing
+ * locally, then retries without the stale ones. An error not explained by any
+ * drift is rethrown.
+ */
+export const queryRecentsHandlingStaleDrives = async (
+  client: CozyClient,
+  onStaleSharedDrives: (driveIds: string[]) => Promise<void>,
+  onMissingSharedDrives: (driveIds: string[]) => Promise<void>
+): Promise<unknown[]> => {
+  try {
+    return await queryRecents(client)
+  } catch (error) {
+    const { staleDriveIds, missingDriveIds } =
+      await findSharedDriveDrift(client)
+    if (staleDriveIds.length === 0 && missingDriveIds.length === 0) {
+      throw error
+    }
+    if (missingDriveIds.length > 0) {
+      await onMissingSharedDrives(missingDriveIds)
+    }
+    await onStaleSharedDrives(staleDriveIds)
+    return queryRecents(client, staleDriveIds)
+  }
 }

--- a/src/dataproxy/worker/worker.ts
+++ b/src/dataproxy/worker/worker.ts
@@ -29,7 +29,10 @@ import {
   DataProxyWorkerPartialState,
   SearchOptions
 } from '@/dataproxy/common/DataProxyInterface'
-import { queryIsTrustedDevice, queryRecents } from '@/dataproxy/worker/data'
+import {
+  queryIsTrustedDevice,
+  queryRecentsHandlingStaleDrives
+} from '@/dataproxy/worker/data'
 import {
   platformWorker,
   searchEngineStorage
@@ -182,11 +185,35 @@ const dataProxy: DataProxyWorker = {
     return results
   },
 
-  recents: () => {
+  recents: async () => {
     if (!client) {
       throw new Error('Client is not initialized')
     }
-    return queryRecents(client)
+
+    return queryRecentsHandlingStaleDrives(
+      client,
+      async staleSharedDriveIds => {
+        for (const driveId of staleSharedDriveIds) {
+          try {
+            await dataProxy.removeSharedDrive(driveId)
+          } catch (e) {
+            log.error(`Failed to remove stale shared drive ${driveId}`, e)
+          }
+        }
+      },
+      async missingSharedDriveIds => {
+        if (!flag('dataproxy.syncMissingSharedDrives')) {
+          return
+        }
+        for (const driveId of missingSharedDriveIds) {
+          try {
+            await dataProxy.addSharedDrive(driveId)
+          } catch (e) {
+            log.error(`Failed to sync missing shared drive ${driveId}`, e)
+          }
+        }
+      }
+    )
   },
 
   requestLink: async (


### PR DESCRIPTION
## Problem

When a user is removed from a shared drive but its local index sticks around, the recents query for that drive gets a 403 from the stack. Because the per-drive queries run in a single batch, that one rejection drops the whole list, so recents shows nothing for any drive.

## Solution

Recents now reconciles the locally indexed shared drives against `/sharings/drives` and skips the ones the stack no longer reports, so we never query a drive we were removed from (and we don't hide genuine failures on the drives that are still valid). A new `dataproxy.cleanStaleSharedDrives` flag additionally drops those stale drives' local database and search index.