### PR TITLE
fix: drop a shared drive's invalid index when the stack 403s recents

### DIFF
--- a/src/dataproxy/worker/data.spec.ts
+++ b/src/dataproxy/worker/data.spec.ts
@@ -93,30 +93,41 @@ describe('queryIsTrustedDevice', () => {
 })
 
 describe('queryRecents', () => {
-  it('does not query shared drives flagged as stale', async () => {
+  it('returns the recents of every doctype it could query', async () => {
     const requestQuery = jest.fn((definition: { doctype: string }) =>
       Promise.resolve({
         data: [{ _id: definition.doctype, updated_at: '2026-01-01T00:00:00Z' }]
       })
     )
 
-    const recents = await queryRecents(setupPouchLink(requestQuery), [
-      'revoked'
-    ])
-
-    const queried = requestQuery.mock.calls.map(
-      call => (call[0] as { doctype: string }).doctype
+    const { recents, staleDriveIds } = await queryRecents(
+      setupPouchLink(requestQuery)
     )
-    expect(queried).toEqual([
-      'io.cozy.files',
-      'io.cozy.files.shareddrives-active'
-    ])
+
+    expect(recents).toHaveLength(3)
+    expect(staleDriveIds).toEqual([])
+  })
+
+  it('reports a shared drive the stack rejects with a 403 as stale and keeps the rest', async () => {
+    const requestQuery = jest.fn((definition: { doctype: string }) =>
+      definition.doctype === 'io.cozy.files.shareddrives-revoked'
+        ? Promise.reject(make403())
+        : Promise.resolve({
+            data: [{ _id: definition.doctype, updated_at: '2026-01-01' }]
+          })
+    )
+
+    const { recents, staleDriveIds } = await queryRecents(
+      setupPouchLink(requestQuery)
+    )
+
+    expect(staleDriveIds).toEqual(['revoked'])
     expect(recents).toHaveLength(2)
   })
 
-  it('surfaces a failure for a drive that is not flagged stale', async () => {
+  it('rejects when the main files doctype answers 403', async () => {
     const requestQuery = jest.fn((definition: { doctype: string }) =>
-      definition.doctype === 'io.cozy.files.shareddrives-revoked'
+      definition.doctype === 'io.cozy.files'
         ? Promise.reject(make403())
         : Promise.resolve({ data: [] })
     )
@@ -124,6 +135,18 @@ describe('queryRecents', () => {
     await expect(
       queryRecents(setupPouchLink(requestQuery))
     ).rejects.toMatchObject({ status: 403 })
+  })
+
+  it('rejects when a shared drive fails with a non-403 error', async () => {
+    const requestQuery = jest.fn((definition: { doctype: string }) =>
+      definition.doctype === 'io.cozy.files.shareddrives-revoked'
+        ? Promise.reject(new Error('Boom'))
+        : Promise.resolve({ data: [] })
+    )
+
+    await expect(queryRecents(setupPouchLink(requestQuery))).rejects.toThrow(
+      'Boom'
+    )
   })
 })
 
@@ -222,7 +245,7 @@ describe('queryRecentsHandlingStaleDrives', () => {
           })
     )
 
-  it('recovers from a 403 by dropping the stale drive and retrying', async () => {
+  it('drops the index of a drive the stack rejected with a 403', async () => {
     const requestQuery = resolveExcept(REVOKED, make403())
     const fetchSharedDrives = jest
       .fn()
@@ -238,7 +261,52 @@ describe('queryRecentsHandlingStaleDrives', () => {
 
     expect(onStale).toHaveBeenCalledWith(['revoked'])
     expect(onMissing).not.toHaveBeenCalled()
-    expect(fetchSharedDrives).toHaveBeenCalledTimes(1)
+    expect(recents).toHaveLength(2)
+  })
+
+  it('does not re-sync a drive it just dropped, even when the stack still lists it', async () => {
+    // Mirror production: the doctypes the link exposes shrink as drives are
+    // removed, so the drift lookup runs against the post-removal state.
+    const doctypes = [
+      'io.cozy.files',
+      'io.cozy.files.shareddrives-active',
+      REVOKED
+    ]
+    mockedGetPouchLink.mockReturnValue({
+      doctypes,
+      pouches: {
+        waitForCurrentReplications: jest.fn().mockResolvedValue(undefined)
+      }
+    } as unknown as ReturnType<typeof getPouchLink>)
+
+    const requestQuery = resolveExcept(REVOKED, make403())
+    // The stack still reports the revoked drive as accessible: only its local
+    // index is invalid, not its membership.
+    const fetchSharedDrives = jest
+      .fn()
+      .mockResolvedValue({ data: [{ _id: 'active' }, { _id: 'revoked' }] })
+    const onStale = jest.fn((ids: string[]) => {
+      for (const id of ids) {
+        const index = doctypes.indexOf(`io.cozy.files.shareddrives-${id}`)
+        if (index !== -1) {
+          doctypes.splice(index, 1)
+        }
+      }
+      return Promise.resolve()
+    })
+    const onMissing = jest.fn().mockResolvedValue(undefined)
+
+    const recents = await queryRecentsHandlingStaleDrives(
+      {
+        requestQuery,
+        collection: () => ({ fetchSharedDrives })
+      } as unknown as CozyClient,
+      onStale,
+      onMissing
+    )
+
+    expect(onStale).toHaveBeenCalledWith(['revoked'])
+    expect(onMissing).not.toHaveBeenCalled()
     expect(recents).toHaveLength(2)
   })
 
@@ -260,6 +328,25 @@ describe('queryRecentsHandlingStaleDrives', () => {
     expect(onStale).toHaveBeenCalledWith(['revoked'])
   })
 
+  it('still returns recents when the missing-drive sync fails', async () => {
+    const requestQuery = resolveExcept(REVOKED, make403())
+    const fetchSharedDrives = jest
+      .fn()
+      .mockRejectedValue(new Error('sharings unavailable'))
+    const onStale = jest.fn().mockResolvedValue(undefined)
+    const onMissing = jest.fn().mockResolvedValue(undefined)
+
+    const recents = await queryRecentsHandlingStaleDrives(
+      makeClient(requestQuery, fetchSharedDrives),
+      onStale,
+      onMissing
+    )
+
+    expect(onStale).toHaveBeenCalledWith(['revoked'])
+    expect(onMissing).not.toHaveBeenCalled()
+    expect(recents).toHaveLength(2)
+  })
+
   it('does not reconcile when the recents query succeeds', async () => {
     const requestQuery = jest.fn(() => Promise.resolve({ data: [] }))
     const fetchSharedDrives = jest.fn()
@@ -277,11 +364,9 @@ describe('queryRecentsHandlingStaleDrives', () => {
     expect(onMissing).not.toHaveBeenCalled()
   })
 
-  it('rethrows the original error when there is no drift', async () => {
+  it('rethrows a non-403 failure without touching shared drives', async () => {
     const requestQuery = resolveExcept(REVOKED, new Error('Boom'))
-    const fetchSharedDrives = jest
-      .fn()
-      .mockResolvedValue({ data: [{ _id: 'active' }, { _id: 'revoked' }] })
+    const fetchSharedDrives = jest.fn()
     const onStale = jest.fn()
     const onMissing = jest.fn()
 
@@ -292,6 +377,7 @@ describe('queryRecentsHandlingStaleDrives', () => {
         onMissing
       )
     ).rejects.toThrow('Boom')
+    expect(fetchSharedDrives).not.toHaveBeenCalled()
     expect(onStale).not.toHaveBeenCalled()
     expect(onMissing).not.toHaveBeenCalled()
   })

--- a/src/dataproxy/worker/data.ts
+++ b/src/dataproxy/worker/data.ts
@@ -119,10 +119,21 @@ function buildRecentsQuery(doctype: string): {
   }
 }
 
+const isForbidden = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  (error as { status?: number }).status === 403
+
+export interface RecentsResult {
+  recents: unknown[]
+  // shared drives whose query the stack rejected with a 403: their local index
+  // is invalid and should be dropped
+  staleDriveIds: string[]
+}
+
 export const queryRecents = async (
-  client: CozyClient,
-  staleSharedDriveIds: string[] = []
-): Promise<unknown[]> => {
+  client: CozyClient
+): Promise<RecentsResult> => {
   if (!client) {
     throw new Error('Client is not initialized')
   }
@@ -131,27 +142,44 @@ export const queryRecents = async (
     throw new Error('PouchLink is not initialized')
   }
 
-  // Skip shared drives the user was removed from: querying them makes the stack
-  // answer 403 and rejects the whole batch
-  const staleDoctypes = new Set(
-    staleSharedDriveIds.map(id => `${SHARED_DRIVE_FILE_DOCTYPE}-${id}`)
-  )
+  // Only the main files view and the shared drives feed recents: keep the query
+  // set in sync with the 403 handling below, which only knows how to drop a
+  // shared drive. A 403 on any other doctype must still surface as a failure.
+  const sharedDrivePrefix = `${SHARED_DRIVE_FILE_DOCTYPE}-`
   const doctypes = pouchLink.doctypes.filter(
-    doctype => doctype.startsWith(FILES_DOCTYPE) && !staleDoctypes.has(doctype)
+    doctype =>
+      doctype === FILES_DOCTYPE || doctype.startsWith(sharedDrivePrefix)
   )
 
   // to be sure to have all the shared drives at first page display
   await pouchLink.pouches.waitForCurrentReplications()
 
-  const sharedDrivesRecentsPromises = doctypes.map(doctype => {
-    const request = buildRecentsQuery(doctype)
-    return client.requestQuery(request.definition, request.options)
-  })
-  const recents: unknown[] = (
-    (await Promise.all(sharedDrivesRecentsPromises)) as Array<{
-      data?: unknown[]
-    }>
-  ).flatMap(recentResult => recentResult.data || [])
+  const staleDriveIds: string[] = []
+
+  // Query each doctype on its own so one shared drive the stack rejects with a
+  // 403 does not sink the whole batch: we keep the other results and report the
+  // offending drive, known from the doctype we queried, as stale. Any other
+  // failure still rejects the batch.
+  const results = await Promise.all(
+    doctypes.map(async doctype => {
+      try {
+        const request = buildRecentsQuery(doctype)
+        const result = (await client.requestQuery(
+          request.definition,
+          request.options
+        )) as { data?: unknown[] }
+        return result.data ?? []
+      } catch (error) {
+        if (isForbidden(error) && doctype.startsWith(sharedDrivePrefix)) {
+          staleDriveIds.push(doctype.slice(sharedDrivePrefix.length))
+          return []
+        }
+        throw error
+      }
+    })
+  )
+
+  const recents: unknown[] = results.flat()
 
   // Sort results from all doctypes by updated_at descending
   recents.sort((a, b) => {
@@ -164,7 +192,7 @@ export const queryRecents = async (
     return dateB - dateA
   })
 
-  return recents
+  return { recents, staleDriveIds }
 }
 
 interface SharedDrive {
@@ -216,29 +244,39 @@ export const findSharedDriveDrift = async (
 }
 
 /**
- * Runs the recents query. If it fails, the reconcile compares the local shared
- * drives against the stack: it lets the caller drop drives gone stale (the stack
- * answers 403 for them) and sync back drives present on the stack but missing
- * locally, then retries without the stale ones. An error not explained by any
- * drift is rethrown.
+ * Runs the recents query, which already drops the shared drives the stack
+ * rejected with a 403 and reports them as stale. When some are stale, the caller
+ * removes their now-invalid local index, and we sync back any drive the stack
+ * lists but we never indexed so it shows up in recents and search again.
  */
 export const queryRecentsHandlingStaleDrives = async (
   client: CozyClient,
   onStaleSharedDrives: (driveIds: string[]) => Promise<void>,
   onMissingSharedDrives: (driveIds: string[]) => Promise<void>
 ): Promise<unknown[]> => {
-  try {
-    return await queryRecents(client)
-  } catch (error) {
-    const { staleDriveIds, missingDriveIds } =
-      await findSharedDriveDrift(client)
-    if (staleDriveIds.length === 0 && missingDriveIds.length === 0) {
-      throw error
-    }
-    if (missingDriveIds.length > 0) {
-      await onMissingSharedDrives(missingDriveIds)
-    }
-    await onStaleSharedDrives(staleDriveIds)
-    return queryRecents(client, staleDriveIds)
+  const { recents, staleDriveIds } = await queryRecents(client)
+
+  if (staleDriveIds.length === 0) {
+    return recents
   }
+
+  await onStaleSharedDrives(staleDriveIds)
+
+  // A stale drive means the local index drifted from the stack, so reconcile the
+  // other way too and sync back drives present on the stack but missing locally.
+  // Exclude the drives we just dropped: the stack may still list them (their
+  // local index is invalid, not their membership), and re-adding them would
+  // recreate the broken index we just removed.
+  try {
+    const staleSet = new Set(staleDriveIds)
+    const { missingDriveIds } = await findSharedDriveDrift(client)
+    const driveIdsToSync = missingDriveIds.filter(id => !staleSet.has(id))
+    if (driveIdsToSync.length > 0) {
+      await onMissingSharedDrives(driveIdsToSync)
+    }
+  } catch (error) {
+    log.warn('Failed to sync missing shared drives', error)
+  }
+
+  return recents
 }


### PR DESCRIPTION
## Context

A shared drive can keep a valid sharing membership while its local index becomes invalid, in which case the stack rejects its recents query with a 403 ("is not a valid doctype name"). The previous recovery only dropped drives the sharings list no longer returned, so this still-listed drive produced no drift, the error was rethrown, and the whole recents page broke.

## Solution

Each files doctype is now queried on its own, so one drive's 403 no longer sinks the batch. The offending drive is identified directly from the query that failed (not from comparing against the sharings list), and its invalid local index is dropped. Drives just dropped are excluded from the missing-drive resync, otherwise a drive the stack still lists would be re-added and the broken index recreated on every call.