### PR TITLE
fix: stop recents repeating files from shared drives

### DIFF
--- a/src/dataproxy/worker/data.spec.ts
+++ b/src/dataproxy/worker/data.spec.ts
@@ -5,7 +5,8 @@ import {
   findSharedDriveDrift,
   queryIsTrustedDevice,
   queryRecents,
-  queryRecentsHandlingStaleDrives
+  queryRecentsHandlingStaleDrives,
+  registerSharedDriveDoctype
 } from '@/dataproxy/worker/data'
 import { getPouchLink } from '@/helpers/client'
 
@@ -147,6 +148,59 @@ describe('queryRecents', () => {
     await expect(queryRecents(setupPouchLink(requestQuery))).rejects.toThrow(
       'Boom'
     )
+  })
+})
+
+describe('registerSharedDriveDoctype', () => {
+  const setup = (
+    doctypes: string[]
+  ): { client: CozyClient; addDoctype: jest.Mock } => {
+    const addDoctype = jest.fn().mockResolvedValue(undefined)
+    mockedGetPouchLink.mockReturnValue({
+      doctypes,
+      addDoctype
+    } as unknown as ReturnType<typeof getPouchLink>)
+    return { client: {} as unknown as CozyClient, addDoctype }
+  }
+
+  it('registers a drive that is not yet on the pouch link', async () => {
+    const { client, addDoctype } = setup(['io.cozy.files'])
+
+    const registered = await registerSharedDriveDoctype(client, 'team')
+
+    expect(registered).toBe(true)
+    expect(addDoctype).toHaveBeenCalledTimes(1)
+    expect(addDoctype).toHaveBeenCalledWith(
+      'io.cozy.files.shareddrives-team',
+      { strategy: 'fromRemote', driveId: 'team' },
+      { shouldStartReplication: true }
+    )
+  })
+
+  it('does not register a drive whose doctype is already on the pouch link', async () => {
+    // Re-adding an already-registered drive must not append its doctype again.
+    const { client, addDoctype } = setup([
+      'io.cozy.files',
+      'io.cozy.files.shareddrives-team'
+    ])
+
+    const registered = await registerSharedDriveDoctype(client, 'team')
+
+    expect(registered).toBe(false)
+    expect(addDoctype).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when there is no pouch link', async () => {
+    mockedGetPouchLink.mockReturnValue(
+      null as unknown as ReturnType<typeof getPouchLink>
+    )
+
+    const registered = await registerSharedDriveDoctype(
+      {} as unknown as CozyClient,
+      'team'
+    )
+
+    expect(registered).toBe(false)
   })
 })
 

--- a/src/dataproxy/worker/data.ts
+++ b/src/dataproxy/worker/data.ts
@@ -195,6 +195,36 @@ export const queryRecents = async (
   return { recents, staleDriveIds }
 }
 
+/**
+ * Registers a shared drive's doctype on the pouch link, or skips it when already
+ * registered. addDoctype does not dedupe, so re-adding a drive would query its
+ * pouch twice and repeat every file in recents. Returns false when already there.
+ */
+export const registerSharedDriveDoctype = async (
+  client: CozyClient,
+  driveId: string
+): Promise<boolean> => {
+  const pouchLink = getPouchLink(client)
+  if (!pouchLink) {
+    return false
+  }
+
+  const doctype = `${SHARED_DRIVE_FILE_DOCTYPE}-${driveId}`
+  if (pouchLink.doctypes.includes(doctype)) {
+    log.debug(`Shared drive ${driveId} already registered, skipping`)
+    return false
+  }
+
+  if (pouchLink.addDoctype) {
+    await pouchLink.addDoctype(
+      doctype,
+      { strategy: 'fromRemote', driveId },
+      { shouldStartReplication: true }
+    )
+  }
+  return true
+}
+
 interface SharedDrive {
   _id: string
   owner?: boolean

--- a/src/dataproxy/worker/worker.ts
+++ b/src/dataproxy/worker/worker.ts
@@ -31,7 +31,8 @@ import {
 } from '@/dataproxy/common/DataProxyInterface'
 import {
   queryIsTrustedDevice,
-  queryRecentsHandlingStaleDrives
+  queryRecentsHandlingStaleDrives,
+  registerSharedDriveDoctype
 } from '@/dataproxy/worker/data'
 import {
   platformWorker,
@@ -273,15 +274,7 @@ const dataProxy: DataProxyWorker = {
     if (!client) {
       throw new Error('Client is required to add a shared drive')
     }
-    const pouchLink = getPouchLink(client)
-    if (pouchLink) {
-      const doctype = `${SHARED_DRIVE_FILE_DOCTYPE}-${driveId}`
-      const replicationOptions = { strategy: 'fromRemote', driveId }
-      const options = { shouldStartReplication: true }
-      if (pouchLink.addDoctype) {
-        await pouchLink.addDoctype(doctype, replicationOptions, options)
-      }
-    }
+    await registerSharedDriveDoctype(client, driveId)
 
     if (!searchEngine) {
       throw new Error('SearchEngine is not initialized')


### PR DESCRIPTION
## Context
Recipients of shared drives saw the same file repeated in Recents, sometimes twice, sometimes four times or more. Each shared drive is registered as its own pouch doctype and recents queries every registered doctype in turn, so a drive whose doctype is registered N times returns each of its files N times.

## Solution
`addSharedDrive` appended the doctype without checking whether the drive was already registered. Make registration idempotent by skipping a drive whose doctype is already on the pouch link.

## Worth knowing
A drive gets registered again whenever `addSharedDrive` fires for one that is already registered. The triggers:
- Several Drive tabs share one dataproxy SharedWorker, and each tab's realtime "created" handler calls `addSharedDrive` for the same event.
- A realtime reconnect (sleep/wake, network change) redelivers the shortcut "created" event.

This is why it was intermittent: the duplicate count per file equals how many times its drive was re-registered, so a user with one tab and a fresh session (or an untrusted device with no local pouch) saw none, while a long multi-tab session accumulated 2x, 4x or more.
